### PR TITLE
change the alacritty theme

### DIFF
--- a/alacritty.yml
+++ b/alacritty.yml
@@ -10,7 +10,6 @@
 # to the user's home directory starting with `~/`.
 #import:
 #  - ~/.config/alacritty/alacritty.yml
-
 # Any items in the `env` entry below will be added as
 # environment variables. Some entries may override variables
 # set by alacritty itself.
@@ -103,7 +102,6 @@ scrolling:
   # Maximum number of lines in the scrollback buffer.
   # Specifying '0' will disable scrolling.
   history: 10000
-
   # Scrolling distance multiplier.
   #multiplier: 3
 
@@ -178,7 +176,6 @@ font:
   # it is recommended to set `use_thin_strokes` to `false`.
   # For some reason I don't need it anymore
   #use_thin_strokes: true
-
   # Use built-in font for box drawing characters.
   #
   # If `true`, Alacritty will use a custom built-in font for box drawing
@@ -188,150 +185,34 @@ font:
 
 # If `true`, bold text is drawn using the bright color variants.
 #draw_bold_text_with_bright_colors: false
-
 # Colors (Tomorrow Night)
 colors:
-  # Default colors
+  name: Material
+  author: ""
   primary:
-    background: '#1d1f21'
-    foreground: '#c5c8c6'
-
-    # Bright and dim foreground colors
-    #
-    # The dimmed foreground color is calculated automatically if it is not
-    # present. If the bright foreground color is not set, or
-    # `draw_bold_text_with_bright_colors` is `false`, the normal foreground
-    # color will be used.
-    dim_foreground: '#828482'
-    bright_foreground: '#eaeaea'
-
-  # Cursor colors
-  #
-  # Colors which should be used to draw the terminal cursor.
-  #
-  # Allowed values are CellForeground/CellBackground, which reference the
-  # affected cell, or hexadecimal colors like #ff00ff.
+    background: "#263238"
+    foreground: "#eceff1"
   cursor:
-    text: CellBackground
-    cursor: CellForeground
-
-  # Vi mode cursor colors
-  #
-  # Colors for the cursor when the vi mode is active.
-  #
-  # Allowed values are CellForeground/CellBackground, which reference the
-  # affected cell, or hexadecimal colors like #ff00ff.
-  vi_mode_cursor:
-    text: CellBackground
-    cursor: CellForeground
-
-  # Search colors
-  #
-  # Colors used for the search bar and match highlighting.
-  search:
-    # Allowed values are CellForeground/CellBackground, which reference the
-    # affected cell, or hexadecimal colors like #ff00ff.
-    matches:
-      foreground: '#000000'
-      background: '#ffffff'
-    focused_match:
-      foreground: '#ffffff'
-      background: '#000000'
-
-    colors.footer_bar:
-      background: '#c5c8c6'
-      foreground: '#1d1f21'
-
-  # Keyboard regex hints
-  hints:
-    # First character in the hint label
-    #
-    # Allowed values are CellForeground/CellBackground, which reference the
-    # affected cell, or hexadecimal colors like #ff00ff.
-    start:
-      foreground: '#1d1f21'
-      background: '#e9ff5e'
-
-    # All characters after the first one in the hint label
-    #
-    # Allowed values are CellForeground/CellBackground, which reference the
-    # affected cell, or hexadecimal colors like #ff00ff.
-    end:
-      foreground: '#e9ff5e'
-      background: '#1d1f21'
-
-  # Line indicator
-  #
-  # Color used for the indicator displaying the position in history during
-  # search and vi mode.
-  #
-  # By default, these will use the opposing primary color.
-  line_indicator:
-    foreground: None
-    background: None
-
-  # Selection colors
-  #
-  # Colors which should be used to draw the selection area.
-  #
-  # Allowed values are CellForeground/CellBackground, which reference the
-  # affected cell, or hexadecimal colors like #ff00ff.
-  selection:
-    text: CellBackground
-    background: CellForeground
-
-  # Normal colors
+    text: "#263238"
+    cursor: "#eceff1"
   normal:
-    black:   '#1d1f21'
-    red:     '#cc6666'
-    green:   '#b5bd68'
-    yellow:  '#f0c674'
-    blue:    '#81a2be'
-    magenta: '#b294bb'
-    cyan:    '#8abeb7'
-    white:   '#c5c8c6'
-
-  # Bright colors
+    black: "#263238"
+    red: "#ff9800"
+    green: "#8bc34a"
+    yellow: "#ffc107"
+    blue: "#03a9f4"
+    magenta: "#e91e63"
+    cyan: "#009688"
+    white: "#cfd8dc"
   bright:
-    black:   '#666666'
-    red:     '#d54e53'
-    green:   '#b9ca4a'
-    yellow:  '#e7c547'
-    blue:    '#7aa6da'
-    magenta: '#c397d8'
-    cyan:    '#70c0b1'
-    white:   '#eaeaea'
-
-  # Dim colors
-  #
-  # If the dim colors are not set, they will be calculated automatically based
-  # on the `normal` colors.
-  dim:
-    black:   '#131415'
-    red:     '#864343'
-    green:   '#777c44'
-    yellow:  '#9e824c'
-    blue:    '#556a7d'
-    magenta: '#75617b'
-    cyan:    '#5b7d78'
-    white:   '#828482'
-
-  # Indexed Colors
-  #
-  # The indexed colors include all colors from 16 to 256.
-  # When these are not set, they're filled with sensible defaults.
-  #
-  # Example:
-  #   `- { index: 16, color: '#ff00ff' }`
-  #
-  indexed_colors: []
-
-  # Transparent cell backgrounds
-  #
-  # Whether or not `window.opacity` applies to all cell backgrounds or only to
-  # the default background. When set to `true` all cells will be transparent
-  # regardless of their background color.
-  transparent_background_colors: false
+    black: "#37474f"
+    red: "#ffa74d"
+    green: "#9ccc65"
+    yellow: "#ffa000"
+    blue: "#81d4fa"
+    magenta: "#ad1457"
+    cyan: "#26a69a"
+    white: "#eceff1"
 
 # Bell
 #
@@ -438,7 +319,6 @@ shell:
   program: /bin/zsh
 #  args:
 #    - --login
-
 # Startup directory
 #
 # Directory the shell is started in. If this is unset, or `None`, the working
@@ -462,15 +342,13 @@ mouse:
 
   # If this is `true`, the cursor is temporarily hidden when typing.
   hide_when_typing: false
-
-# Regex hints
-#
-# Terminal hints can be used to find text in the visible part of the terminal
-# and pipe it to other applications.
-#hints:
+  # Regex hints
+  #
+  # Terminal hints can be used to find text in the visible part of the terminal
+  # and pipe it to other applications.
+  #hints:
   # Keys used for the hint labels.
   #alphabet: "jfkdls;ahgurieowpq"
-
   # List with all available hints
   #
   # Each hint must have a `regex` and either an `action` or a `command` field.
@@ -506,247 +384,245 @@ mouse:
   #   binding:
   #     key: U
   #     mods: Control|Shift
-
-# Mouse bindings
-#
-# Mouse bindings are specified as a list of objects, much like the key
-# bindings further below.
-#
-# To trigger mouse bindings when an application running within Alacritty
-# captures the mouse, the `Shift` modifier is automatically added as a
-# requirement.
-#
-# Each mouse binding will specify a:
-#
-# - `mouse`:
-#
-#   - Middle
-#   - Left
-#   - Right
-#   - Numeric identifier such as `5`
-#
-# - `action` (see key bindings for actions not exclusive to mouse mode)
-#
-# - Mouse exclusive actions:
-#
-#   - ExpandSelection
-#       Expand the selection to the current mouse cursor location.
-#
-# And optionally:
-#
-# - `mods` (see key bindings)
-#mouse_bindings:
-#  - { mouse: Right,                 action: ExpandSelection }
-#  - { mouse: Right,  mods: Control, action: ExpandSelection }
-#  - { mouse: Middle, mode: ~Vi,     action: PasteSelection  }
-
-# Key bindings
-#
-# Key bindings are specified as a list of objects. For example, this is the
-# default paste binding:
-#
-# `- { key: V, mods: Control|Shift, action: Paste }`
-#
-# Each key binding will specify a:
-#
-# - `key`: Identifier of the key pressed
-#
-#    - A-Z
-#    - F1-F24
-#    - Key0-Key9
-#
-#    A full list with available key codes can be found here:
-#    https://docs.rs/glutin/*/glutin/event/enum.VirtualKeyCode.html#variants
-#
-#    Instead of using the name of the keys, the `key` field also supports using
-#    the scancode of the desired key. Scancodes have to be specified as a
-#    decimal number. This command will allow you to display the hex scancodes
-#    for certain keys:
-#
-#       `showkey --scancodes`.
-#
-# Then exactly one of:
-#
-# - `chars`: Send a byte sequence to the running application
-#
-#    The `chars` field writes the specified string to the terminal. This makes
-#    it possible to pass escape sequences. To find escape codes for bindings
-#    like `PageUp` (`"\x1b[5~"`), you can run the command `showkey -a` outside
-#    of tmux. Note that applications use terminfo to map escape sequences back
-#    to keys. It is therefore required to update the terminfo when changing an
-#    escape sequence.
-#
-# - `action`: Execute a predefined action
-#
-#   - ToggleViMode
-#   - SearchForward
-#       Start searching toward the right of the search origin.
-#   - SearchBackward
-#       Start searching toward the left of the search origin.
-#   - Copy
-#   - Paste
-#   - IncreaseFontSize
-#   - DecreaseFontSize
-#   - ResetFontSize
-#   - ScrollPageUp
-#   - ScrollPageDown
-#   - ScrollHalfPageUp
-#   - ScrollHalfPageDown
-#   - ScrollLineUp
-#   - ScrollLineDown
-#   - ScrollToTop
-#   - ScrollToBottom
-#   - ClearHistory
-#       Remove the terminal's scrollback history.
-#   - Hide
-#       Hide the Alacritty window.
-#   - Minimize
-#       Minimize the Alacritty window.
-#   - Quit
-#       Quit Alacritty.
-#   - ToggleFullscreen
-#   - SpawnNewInstance
-#       Spawn a new instance of Alacritty.
-#   - CreateNewWindow
-#       Create a new Alacritty window from the current process.
-#   - ClearLogNotice
-#       Clear Alacritty's UI warning and error notice.
-#   - ClearSelection
-#       Remove the active selection.
-#   - ReceiveChar
-#   - None
-#
-# - Vi mode exclusive actions:
-#
-#   - Open
-#       Perform the action of the first matching hint under the vi mode cursor
-#       with `mouse.enabled` set to `true`.
-#   - ToggleNormalSelection
-#   - ToggleLineSelection
-#   - ToggleBlockSelection
-#   - ToggleSemanticSelection
-#       Toggle semantic selection based on `selection.semantic_escape_chars`.
-#
-# - Vi mode exclusive cursor motion actions:
-#
-#   - Up
-#       One line up.
-#   - Down
-#       One line down.
-#   - Left
-#       One character left.
-#   - Right
-#       One character right.
-#   - First
-#       First column, or beginning of the line when already at the first column.
-#   - Last
-#       Last column, or beginning of the line when already at the last column.
-#   - FirstOccupied
-#       First non-empty cell in this terminal row, or first non-empty cell of
-#       the line when already at the first cell of the row.
-#   - High
-#       Top of the screen.
-#   - Middle
-#       Center of the screen.
-#   - Low
-#       Bottom of the screen.
-#   - SemanticLeft
-#       Start of the previous semantically separated word.
-#   - SemanticRight
-#       Start of the next semantically separated word.
-#   - SemanticLeftEnd
-#       End of the previous semantically separated word.
-#   - SemanticRightEnd
-#       End of the next semantically separated word.
-#   - WordLeft
-#       Start of the previous whitespace separated word.
-#   - WordRight
-#       Start of the next whitespace separated word.
-#   - WordLeftEnd
-#       End of the previous whitespace separated word.
-#   - WordRightEnd
-#       End of the next whitespace separated word.
-#   - Bracket
-#       Character matching the bracket at the cursor's location.
-#   - SearchNext
-#       Beginning of the next match.
-#   - SearchPrevious
-#       Beginning of the previous match.
-#   - SearchStart
-#       Start of the match to the left of the vi mode cursor.
-#   - SearchEnd
-#       End of the match to the right of the vi mode cursor.
-#
-# - Search mode exclusive actions:
-#   - SearchFocusNext
-#       Move the focus to the next search match.
-#   - SearchFocusPrevious
-#       Move the focus to the previous search match.
-#   - SearchConfirm
-#   - SearchCancel
-#   - SearchClear
-#       Reset the search regex.
-#   - SearchDeleteWord
-#       Delete the last word in the search regex.
-#   - SearchHistoryPrevious
-#       Go to the previous regex in the search history.
-#   - SearchHistoryNext
-#       Go to the next regex in the search history.
-#
-# - macOS exclusive actions:
-#   - ToggleSimpleFullscreen
-#       Enter fullscreen without occupying another space.
-#
-# - Linux/BSD exclusive actions:
-#
-#   - CopySelection
-#       Copy from the selection buffer.
-#   - PasteSelection
-#       Paste from the selection buffer.
-#
-# - `command`: Fork and execute a specified command plus arguments
-#
-#    The `command` field must be a map containing a `program` string and an
-#    `args` array of command line parameter strings. For example:
-#       `{ program: "alacritty", args: ["-e", "vttest"] }`
-#
-# And optionally:
-#
-# - `mods`: Key modifiers to filter binding actions
-#
-#    - Command
-#    - Control
-#    - Option
-#    - Super
-#    - Shift
-#    - Alt
-#
-#    Multiple `mods` can be combined using `|` like this:
-#       `mods: Control|Shift`.
-#    Whitespace and capitalization are relevant and must match the example.
-#
-# - `mode`: Indicate a binding for only specific terminal reported modes
-#
-#    This is mainly used to send applications the correct escape sequences
-#    when in different modes.
-#
-#    - AppCursor
-#    - AppKeypad
-#    - Search
-#    - Alt
-#    - Vi
-#
-#    A `~` operator can be used before a mode to apply the binding whenever
-#    the mode is *not* active, e.g. `~Alt`.
-#
-# Bindings are always filled by default, but will be replaced when a new
-# binding with the same triggers is defined. To unset a default binding, it can
-# be mapped to the `ReceiveChar` action. Alternatively, you can use `None` for
-# a no-op if you do not wish to receive input characters for that binding.
-#
-# If the same trigger is assigned to multiple actions, all of them are executed
-# in the order they were defined in.
-#key_bindings:
+  # Mouse bindings
+  #
+  # Mouse bindings are specified as a list of objects, much like the key
+  # bindings further below.
+  #
+  # To trigger mouse bindings when an application running within Alacritty
+  # captures the mouse, the `Shift` modifier is automatically added as a
+  # requirement.
+  #
+  # Each mouse binding will specify a:
+  #
+  # - `mouse`:
+  #
+  #   - Middle
+  #   - Left
+  #   - Right
+  #   - Numeric identifier such as `5`
+  #
+  # - `action` (see key bindings for actions not exclusive to mouse mode)
+  #
+  # - Mouse exclusive actions:
+  #
+  #   - ExpandSelection
+  #       Expand the selection to the current mouse cursor location.
+  #
+  # And optionally:
+  #
+  # - `mods` (see key bindings)
+  #mouse_bindings:
+  #  - { mouse: Right,                 action: ExpandSelection }
+  #  - { mouse: Right,  mods: Control, action: ExpandSelection }
+  #  - { mouse: Middle, mode: ~Vi,     action: PasteSelection  }
+  # Key bindings
+  #
+  # Key bindings are specified as a list of objects. For example, this is the
+  # default paste binding:
+  #
+  # `- { key: V, mods: Control|Shift, action: Paste }`
+  #
+  # Each key binding will specify a:
+  #
+  # - `key`: Identifier of the key pressed
+  #
+  #    - A-Z
+  #    - F1-F24
+  #    - Key0-Key9
+  #
+  #    A full list with available key codes can be found here:
+  #    https://docs.rs/glutin/*/glutin/event/enum.VirtualKeyCode.html#variants
+  #
+  #    Instead of using the name of the keys, the `key` field also supports using
+  #    the scancode of the desired key. Scancodes have to be specified as a
+  #    decimal number. This command will allow you to display the hex scancodes
+  #    for certain keys:
+  #
+  #       `showkey --scancodes`.
+  #
+  # Then exactly one of:
+  #
+  # - `chars`: Send a byte sequence to the running application
+  #
+  #    The `chars` field writes the specified string to the terminal. This makes
+  #    it possible to pass escape sequences. To find escape codes for bindings
+  #    like `PageUp` (`"\x1b[5~"`), you can run the command `showkey -a` outside
+  #    of tmux. Note that applications use terminfo to map escape sequences back
+  #    to keys. It is therefore required to update the terminfo when changing an
+  #    escape sequence.
+  #
+  # - `action`: Execute a predefined action
+  #
+  #   - ToggleViMode
+  #   - SearchForward
+  #       Start searching toward the right of the search origin.
+  #   - SearchBackward
+  #       Start searching toward the left of the search origin.
+  #   - Copy
+  #   - Paste
+  #   - IncreaseFontSize
+  #   - DecreaseFontSize
+  #   - ResetFontSize
+  #   - ScrollPageUp
+  #   - ScrollPageDown
+  #   - ScrollHalfPageUp
+  #   - ScrollHalfPageDown
+  #   - ScrollLineUp
+  #   - ScrollLineDown
+  #   - ScrollToTop
+  #   - ScrollToBottom
+  #   - ClearHistory
+  #       Remove the terminal's scrollback history.
+  #   - Hide
+  #       Hide the Alacritty window.
+  #   - Minimize
+  #       Minimize the Alacritty window.
+  #   - Quit
+  #       Quit Alacritty.
+  #   - ToggleFullscreen
+  #   - SpawnNewInstance
+  #       Spawn a new instance of Alacritty.
+  #   - CreateNewWindow
+  #       Create a new Alacritty window from the current process.
+  #   - ClearLogNotice
+  #       Clear Alacritty's UI warning and error notice.
+  #   - ClearSelection
+  #       Remove the active selection.
+  #   - ReceiveChar
+  #   - None
+  #
+  # - Vi mode exclusive actions:
+  #
+  #   - Open
+  #       Perform the action of the first matching hint under the vi mode cursor
+  #       with `mouse.enabled` set to `true`.
+  #   - ToggleNormalSelection
+  #   - ToggleLineSelection
+  #   - ToggleBlockSelection
+  #   - ToggleSemanticSelection
+  #       Toggle semantic selection based on `selection.semantic_escape_chars`.
+  #
+  # - Vi mode exclusive cursor motion actions:
+  #
+  #   - Up
+  #       One line up.
+  #   - Down
+  #       One line down.
+  #   - Left
+  #       One character left.
+  #   - Right
+  #       One character right.
+  #   - First
+  #       First column, or beginning of the line when already at the first column.
+  #   - Last
+  #       Last column, or beginning of the line when already at the last column.
+  #   - FirstOccupied
+  #       First non-empty cell in this terminal row, or first non-empty cell of
+  #       the line when already at the first cell of the row.
+  #   - High
+  #       Top of the screen.
+  #   - Middle
+  #       Center of the screen.
+  #   - Low
+  #       Bottom of the screen.
+  #   - SemanticLeft
+  #       Start of the previous semantically separated word.
+  #   - SemanticRight
+  #       Start of the next semantically separated word.
+  #   - SemanticLeftEnd
+  #       End of the previous semantically separated word.
+  #   - SemanticRightEnd
+  #       End of the next semantically separated word.
+  #   - WordLeft
+  #       Start of the previous whitespace separated word.
+  #   - WordRight
+  #       Start of the next whitespace separated word.
+  #   - WordLeftEnd
+  #       End of the previous whitespace separated word.
+  #   - WordRightEnd
+  #       End of the next whitespace separated word.
+  #   - Bracket
+  #       Character matching the bracket at the cursor's location.
+  #   - SearchNext
+  #       Beginning of the next match.
+  #   - SearchPrevious
+  #       Beginning of the previous match.
+  #   - SearchStart
+  #       Start of the match to the left of the vi mode cursor.
+  #   - SearchEnd
+  #       End of the match to the right of the vi mode cursor.
+  #
+  # - Search mode exclusive actions:
+  #   - SearchFocusNext
+  #       Move the focus to the next search match.
+  #   - SearchFocusPrevious
+  #       Move the focus to the previous search match.
+  #   - SearchConfirm
+  #   - SearchCancel
+  #   - SearchClear
+  #       Reset the search regex.
+  #   - SearchDeleteWord
+  #       Delete the last word in the search regex.
+  #   - SearchHistoryPrevious
+  #       Go to the previous regex in the search history.
+  #   - SearchHistoryNext
+  #       Go to the next regex in the search history.
+  #
+  # - macOS exclusive actions:
+  #   - ToggleSimpleFullscreen
+  #       Enter fullscreen without occupying another space.
+  #
+  # - Linux/BSD exclusive actions:
+  #
+  #   - CopySelection
+  #       Copy from the selection buffer.
+  #   - PasteSelection
+  #       Paste from the selection buffer.
+  #
+  # - `command`: Fork and execute a specified command plus arguments
+  #
+  #    The `command` field must be a map containing a `program` string and an
+  #    `args` array of command line parameter strings. For example:
+  #       `{ program: "alacritty", args: ["-e", "vttest"] }`
+  #
+  # And optionally:
+  #
+  # - `mods`: Key modifiers to filter binding actions
+  #
+  #    - Command
+  #    - Control
+  #    - Option
+  #    - Super
+  #    - Shift
+  #    - Alt
+  #
+  #    Multiple `mods` can be combined using `|` like this:
+  #       `mods: Control|Shift`.
+  #    Whitespace and capitalization are relevant and must match the example.
+  #
+  # - `mode`: Indicate a binding for only specific terminal reported modes
+  #
+  #    This is mainly used to send applications the correct escape sequences
+  #    when in different modes.
+  #
+  #    - AppCursor
+  #    - AppKeypad
+  #    - Search
+  #    - Alt
+  #    - Vi
+  #
+  #    A `~` operator can be used before a mode to apply the binding whenever
+  #    the mode is *not* active, e.g. `~Alt`.
+  #
+  # Bindings are always filled by default, but will be replaced when a new
+  # binding with the same triggers is defined. To unset a default binding, it can
+  # be mapped to the `ReceiveChar` action. Alternatively, you can use `None` for
+  # a no-op if you do not wish to receive input characters for that binding.
+  #
+  # If the same trigger is assigned to multiple actions, all of them are executed
+  # in the order they were defined in.
+  #key_bindings:
   #- { key: Paste,                                       action: Paste          }
   #- { key: Copy,                                        action: Copy           }
   #- { key: L,         mods: Control,                    action: ClearLogNotice }
@@ -755,7 +631,6 @@ mouse:
   #- { key: PageDown,  mods: Shift,   mode: ~Alt,        action: ScrollPageDown }
   #- { key: Home,      mods: Shift,   mode: ~Alt,        action: ScrollToTop,   }
   #- { key: End,       mods: Shift,   mode: ~Alt,        action: ScrollToBottom }
-
   # Vi Mode
   #- { key: Space,  mods: Shift|Control, mode: ~Search,    action: ToggleViMode            }
   #- { key: Space,  mods: Shift|Control, mode: Vi|~Search, action: ScrollToBottom          }
@@ -804,7 +679,6 @@ mouse:
   #- { key: Slash,  mods: Shift,         mode: Vi|~Search, action: SearchBackward          }
   #- { key: N,                           mode: Vi|~Search, action: SearchNext              }
   #- { key: N,      mods: Shift,         mode: Vi|~Search, action: SearchPrevious          }
-
   # Search Mode
   #- { key: Return,                mode: Search|Vi,  action: SearchConfirm         }
   #- { key: Escape,                mode: Search,     action: SearchCancel          }
@@ -817,7 +691,6 @@ mouse:
   #- { key: Down,                  mode: Search,     action: SearchHistoryNext     }
   #- { key: Return,                mode: Search|~Vi, action: SearchFocusNext       }
   #- { key: Return, mods: Shift,   mode: Search|~Vi, action: SearchFocusPrevious   }
-
   # (Windows, Linux, and BSD only)
   #- { key: V,              mods: Control|Shift, mode: ~Vi,        action: Paste            }
   #- { key: C,              mods: Control|Shift,                   action: Copy             }
@@ -831,10 +704,8 @@ mouse:
   #- { key: NumpadAdd,      mods: Control,                         action: IncreaseFontSize }
   #- { key: Minus,          mods: Control,                         action: DecreaseFontSize }
   #- { key: NumpadSubtract, mods: Control,                         action: DecreaseFontSize }
-
   # (Windows only)
   #- { key: Return,   mods: Alt,           action: ToggleFullscreen }
-
   # (macOS only)
   #- { key: K,              mods: Command, mode: ~Vi|~Search, chars: "\x0c"                 }
   #- { key: K,              mods: Command, mode: ~Vi|~Search, action: ClearHistory          }
@@ -856,14 +727,11 @@ mouse:
   #- { key: F,              mods: Command|Control,            action: ToggleFullscreen      }
   #- { key: F,              mods: Command, mode: ~Search,     action: SearchForward         }
   #- { key: B,              mods: Command, mode: ~Search,     action: SearchBackward        }
-
-#debug:
+  #debug:
   # Display the time it takes to redraw each frame.
   #render_timer: false
-
   # Keep the log file after quitting Alacritty.
   #persistent_logging: false
-
   # Log level
   #
   # Values for `log_level`:
@@ -874,6 +742,6 @@ mouse:
   #   - Debug
   #   - Trace
   #log_level: Warn
-
   # Print all received window events.
   #print_events: false
+theme: Material


### PR DESCRIPTION
Closes #12 
For the questions
- I figured out about `alacritty-themes` in arch linux is in the [AUR](https://aur.archlinux.org/packages/alacritty-themes) package. It's a node app that change the alacritty.yml to change the colors and apply themes more in this [path](https://github.com/rajasegar/alacritty-themes)
- I changed the theme with the previous tool.
- In the IRC channel of #alacritty I figured out that It exists a vi-mode I can enter to a kind normal mode with `Ctrl + Shif + Space` and I can enter to a visual mode and use the yank command. I need to figure out more about vi-mode