### PR TITLE
use-the-default-branch-ofcmpcopilot

### DIFF
--- a/lua/plugins/copilot-cmp.lua
+++ b/lua/plugins/copilot-cmp.lua
@@ -1,7 +1,6 @@
 return {
   "zbirenbaum/copilot-cmp",
   event = { "InsertEnter", "LspAttach" },
-  branch = "formatting-fixes",
   config = function()
     require("copilot_cmp").setup()
   end


### PR DESCRIPTION
Fix #75 