### PR TITLE
bugfix/remove-tag-on-telescope-instalation

### DIFF
--- a/config/nvim/lua/plugins/telescope.lua
+++ b/config/nvim/lua/plugins/telescope.lua
@@ -1,7 +1,6 @@
 return {
   {
     'nvim-telescope/telescope.nvim',
-    tag = '0.1.1',
     dependencies = {
       'nvim-lua/plenary.nvim',
       'nvim-telescope/telescope-fzy-native.nvim',


### PR DESCRIPTION
Fix #92 

- Remove the tag in lazy