### PR TITLE
bugfix/fix-solargraph-and-lua-ls-issues

### DIFF
--- a/config/nvim/lua/plugins/efmls-confing-nvim/languages.lua
+++ b/config/nvim/lua/plugins/efmls-confing-nvim/languages.lua
@@ -1,8 +1,5 @@
 local eslint_d = require 'efmls-configs.linters.eslint_d'
 local eslint_d_formatter = require 'efmls-configs.formatters.eslint_d'
-local stylua = require 'efmls-configs.formatters.stylua'
-local luacheck = require 'efmls-configs.linters.luacheck'
-local rubocop = require 'efmls-configs.linters.rubocop'
 
 local js_languages = { eslint_d, eslint_d_formatter }
 
@@ -11,6 +8,4 @@ return {
   javascriptreact = js_languages,
   typescript = js_languages,
   typescriptreact = js_languages,
-  lua = { stylua, luacheck },
-  ruby = { rubocop }
 }

--- a/config/nvim/lua/plugins/nvim-lspconfig/default_config.lua
+++ b/config/nvim/lua/plugins/nvim-lspconfig/default_config.lua
@@ -1,6 +1,8 @@
 local capabilities = vim.lsp.protocol.make_client_capabilities()
 capabilities = require('cmp_nvim_lsp').default_capabilities(capabilities)
+local function default_on_attach(client) print('Attaching to ' .. client.name) end
 
 return {
+  on_attach = default_on_attach,
   capabilities = capabilities
 }

--- a/config/nvim/lua/plugins/nvim-lspconfig/lua_config.lua
+++ b/config/nvim/lua/plugins/nvim-lspconfig/lua_config.lua
@@ -1,19 +1,23 @@
-local default_config = require 'plugins.nvim-lspconfig.default_config'
+local default_config = require("plugins.nvim-lspconfig.default_config")
 
-return  {
+return {
   on_attach = default_config.on_attach,
   capabilities = default_config.capabilities,
-  settings = {
-    Lua = {
-      runtime = { version = 'LuaJIT' },
-      diagnostics = { globals = { 'vim' } },
-      workspace = {
-        maxPreload = 10000,
-        library = vim.api.nvim_get_runtime_file('', true),
-        checkThirdParty = false,
-      },
-      telemetry = { enable = false }
-    }
-  }
+  on_init = function(client)
+    local path = client.workspace_folders[1].name
+    if not vim.loop.fs_stat(path .. "/.luarc.json") and not vim.loop.fs_stat(path .. "/.luarc.jsonc") then
+      client.config.settings = vim.tbl_deep_extend("force", client.config.settings, {
+        Lua = {
+          runtime = { version = "LuaJIT" },
+          workspace = {
+            checkThirdParty = false,
+            library = { vim.env.VIMRUNTIME },
+          },
+          telemetry = { enable = false },
+        },
+      })
+      client.notify("workspace/didChangeConfiguration", { settings = client.config.settings })
+    end
+    return true
+  end,
 }
-


### PR DESCRIPTION
Fix #98 
- Remove the efm linters and formats of ruby and lua
- Run the bundle install cmd in the ruby projects
- Update the lua_ls config like the documentation suggest
- Print the ls server