### PR TITLE
feature/add-keymap-to-tab-iamb

### DIFF
--- a/config/iamb/config.toml
+++ b/config/iamb/config.toml
@@ -13,3 +13,6 @@ members = ["server", "~localpart"]
 
 [settings.image_preview]
 protocol.type="kitty"
+
+[macros.insert]
+"<Tab>" = "<C-n>"


### PR DESCRIPTION
Fix #137
- Add the keymap tab to autocomplete