### PR TITLE
feature/new-waybar-view

### DIFF
--- a/config/waybar/config.jsonc
+++ b/config/waybar/config.jsonc
@@ -10,13 +10,13 @@
     "reload_style_on_change": true,
     // Choose the order of the modules
     "modules-left": [
-        "custom/arch",
+        "sway/workspaces",
         "sway/mode",
         "sway/scratchpad",
         "custom/media"
     ],
     "modules-center": [
-        "sway/workspaces"
+        "clock"
     ],
     "modules-right": [
         "mpd",
@@ -27,20 +27,9 @@
         "pulseaudio",
         "network",
         "tray",
-        "clock",
         "battery",
         "custom/power"
     ],
-     // Modules configuration
-     "custom/arch" : {
-       "format": "󰣇"
-     },
-
-
-     "tray": {
-       "format" : "hola"
-     },
-
      "sway/workspaces": {
          "disable-scroll": true,
          "all-outputs": false,
@@ -109,6 +98,7 @@
         }
     },
     "clock": {
+        "format": "{:%H:%M %A, %B %d}",
         "tooltip-format": "<big>{:%Y %B}</big>\n<tt><small>{calendar}</small></tt>",
         "format-alt": "{:%d/%m/%Y}"
     },


### PR DESCRIPTION
Fix #177
- Move the workspaces to the modules-left
- Add the date in the clock module format
- Remove the custom/arch module
- Remove the custom try setup